### PR TITLE
Fix link to LICENSE file within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - [Intro](#Intro)
 - [Contributing](./CONTRIBUTING.md)
-- [License](./LICENSE.md)
+- [License](./LICENSE)
 - [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
 - [Backlog](https://waffle.io/Microsoft/agogosml)
   


### PR DESCRIPTION
README.md referenced the license file as `LICENSE.md` when the actual file is named `LICENSE` (without the `.md` extension). This results in a 404 when a view clicks the link shown by GitHub.

This fix assumes that the file is named correctly, but that the link in README.md is wrong.