### PR TITLE
Fixed docker registry naming issue 

### DIFF
--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/Dockerfile.input_reader
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/Dockerfile.input_reader
@@ -1,13 +1,13 @@
 ARG CONTAINER_REG
 ARG AGOGOSML_TAG="latest"
 
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} as builder
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} as builder
 
 WORKDIR /usr/src/agogosml
 COPY . ./input_reader
 
 # Release
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} AS input_reader
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} AS input_reader
 
 WORKDIR /input_reader
 COPY --from=builder /usr/src/agogosml/input_reader /input_reader

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/Dockerfile.output_writer
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/Dockerfile.output_writer
@@ -1,14 +1,14 @@
 ARG CONTAINER_REG
 ARG AGOGOSML_TAG="latest"
 
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} as builder
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} as builder
 
 # Copy the app
 WORKDIR /usr/src/agogosml
 COPY . ./output_writer
 
 # Release
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} AS output_writer
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} AS output_writer
 
 WORKDIR /output_writer
 COPY --from=builder /usr/src/agogosml/output_writer /output_writer


### PR DESCRIPTION
Dockerfile generated by CLI for input_reader and output_writer has a missing "/"  when referring to docker registry name and the image name. This cause DevOps CI pipeline to fail. Fix is to add the "/" to separate registry name with the image name properly. 

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [x ] Have secrets been stripped before committing? 
