### PR TITLE
Fix constructor signature

### DIFF
--- a/agogosml/agogosml/common/abstract_streaming_client.py
+++ b/agogosml/agogosml/common/abstract_streaming_client.py
@@ -1,12 +1,17 @@
 """Abstract streaming client class"""
 
 from abc import ABC, abstractmethod
+from typing import Dict
 
 
 class AbstractStreamingClient(ABC):
-    """Abstract Streaming Client"""
     @abstractmethod
-    def __init__(self):
+    def __init__(self, config: Dict[str, str]):
+        """
+        Abstract Streaming Client
+
+        :param config: Dictionary file with all the relevant parameters.
+        """
         pass
 
     @abstractmethod

--- a/agogosml/agogosml/common/eventhub_streaming_client.py
+++ b/agogosml/agogosml/common/eventhub_streaming_client.py
@@ -18,7 +18,7 @@ class EventHubStreamingClient(AbstractStreamingClient):
 
         :param config: Dictionary file with all the relevant parameters.
         """
-        super().__init__()
+
         self.message_callback = None
         self.config = config
         self.storage_account_name = self.config.get("AZURE_STORAGE_ACCOUNT")

--- a/agogosml/agogosml/common/eventhub_streaming_client.py
+++ b/agogosml/agogosml/common/eventhub_streaming_client.py
@@ -16,6 +16,17 @@ class EventHubStreamingClient(AbstractStreamingClient):
         """
         Class to create an EventHubStreamingClient instance.
 
+        Configuration keys:
+          AZURE_STORAGE_ACCESS_KEY
+          AZURE_STORAGE_ACCOUNT
+          EVENT_HUB_CONSUMER_GROUP
+          EVENT_HUB_NAME
+          EVENT_HUB_NAMESPACE
+          EVENT_HUB_SAS_KEY
+          EVENT_HUB_SAS_POLICY
+          LEASE_CONTAINER_NAME
+          TIMEOUT
+
         :param config: Dictionary file with all the relevant parameters.
         """
 

--- a/agogosml/agogosml/common/kafka_streaming_client.py
+++ b/agogosml/agogosml/common/kafka_streaming_client.py
@@ -14,8 +14,15 @@ class KafkaStreamingClient(AbstractStreamingClient):
         """
         Class to create a KafkaStreamingClient instance.
 
+        Configuration keys:
+          APP_HOST
+          APP_PORT
+          KAFKA_ADDRESS
+          KAFKA_CONSUMER_GROUP
+          KAFKA_TOPIC
+          TIMEOUT
+
         :param config: Dictionary file with all the relevant parameters.
-        :param topic: A string kafka topic.
         """
 
         self.topic = config.get("KAFKA_TOPIC")


### PR DESCRIPTION
All the subclasses take a configuration dictionary as constructor argument, so the interface definition should also mention it. In addition to improving documentation, this change will also make it safer to use reflection to look up and instantiate specific implementations of the interface since the constructor signature now is part of the official interface.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? **Not applicable: documentation change**
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)? **Passes Docker build**
- [x] Have you added tests to cover your changes? **Not applicable: documentation change**
- [x] Have you linted your code prior to submission? **Passes Docker build**
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). **Not applicable: documentation change**
- [x] Have secrets been stripped before committing? **Not applicable: documentation change**
