### PR TITLE
Replace os.path with pathlib

### DIFF
--- a/agogosml/agogosml/utils/logger.py
+++ b/agogosml/agogosml/utils/logger.py
@@ -1,6 +1,8 @@
 """ Logger """
 import os
 import logging.config
+from pathlib import Path
+
 import yaml
 
 
@@ -16,12 +18,14 @@ class Logger(object):
                       env_key='LOG_CFG'):
         """Setup logging configuration."""
 
-        path = log_path
         value = os.getenv(env_key, None)
         if value:
-            path = value
-        if os.path.exists(path):
-            with open(path, 'rt') as f:
+            path = Path(value)
+        else:
+            path = Path(log_path)
+
+        if path.is_file():
+            with path.open('rt') as f:
                 config = yaml.safe_load(f.read())
             logging.config.dictConfig(config)
         else:

--- a/agogosml_cli/cli/templates/apps/simple/{{cookiecutter.PROJECT_NAME_SLUG}}/testapp.py
+++ b/agogosml_cli/cli/templates/apps/simple/{{cookiecutter.PROJECT_NAME_SLUG}}/testapp.py
@@ -1,13 +1,15 @@
 """ Unit tests for the customer app """
 import os
 import json
+from pathlib import Path
+
 from dotenv import load_dotenv
 from hypothesis import given
 from hypothesis.strategies import fixed_dictionaries, text, characters, integers
 import datahelper
 
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
+BASE_DIR = Path(__file__).parent.absolute()
+load_dotenv(dotenv_path=str(BASE_DIR / ".env"))
 
 SCHEMA_FILEPATH = os.getenv('SCHEMA_FILEPATH')
 

--- a/agogosml_cli/cli/utils.py
+++ b/agogosml_cli/cli/utils.py
@@ -2,21 +2,24 @@
 
 """Utility functions."""
 
-import os
 import json
+from pathlib import Path
+from typing import Union
+
 from jsonschema import validate
 
 
-SCHEMA_FILE = os.path.join(os.path.dirname(__file__), 'manifest.schema.json')
-TEMPLATES_FOLDER = os.path.join(os.path.dirname(__file__), 'templates')
+MODULE_PATH = Path(__file__).parent
+SCHEMA_FILE = MODULE_PATH / 'manifest.schema.json'
+TEMPLATES_FOLDER = MODULE_PATH / 'templates'
 
 
-def get_template_full_filepath(file: str) -> str:
+def get_template_full_filepath(file: Union[str, Path]) -> Path:
     """Get full file path for template file.
     Args:
         file (string): Name of the file in module
     """
-    return os.path.join(TEMPLATES_FOLDER, file)
+    return TEMPLATES_FOLDER / file
 
 
 def validate_manifest(manifest_json: object) -> None:
@@ -25,9 +28,7 @@ def validate_manifest(manifest_json: object) -> None:
     Args:
         manifest_json (object):
     """
-    module_path = os.path.dirname(__file__)
-    schema_file = os.path.join(module_path, SCHEMA_FILE)
-    with open(schema_file) as f:
+    with SCHEMA_FILE.open() as f:
         schema_json = json.load(f)
     validate(manifest_json, schema_json)
     return

--- a/agogosml_cli/tests/test_cli_generate.py
+++ b/agogosml_cli/tests/test_cli_generate.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for `agogosml_cli` package."""
 
-import os
 import json
+from pathlib import Path
+
 from click.testing import CliRunner
 import cli.generate as generate
 import tests.test_utils as test_utils
@@ -188,8 +189,9 @@ def test_generate_invalid_schema():
 
 
 def _assert_template_files_exist(folder='.'):
+    folder = Path(folder)
     for proj_file in EXPECTED_OUTPUT_PROJ_FILES:
-        assert os.path.exists(os.path.join(folder, proj_file))
+        assert (folder / proj_file).exists()
 
 
 def _create_test_manifest_azure(folder='.'):
@@ -212,10 +214,10 @@ def _create_test_manifest_azure(folder='.'):
     }
     """
     manifest = json.loads(manifest_str)
-    if not os.path.isdir(folder):
-        os.makedirs(folder)
-    outfile = os.path.join(folder, 'manifest.json')
-    with open(outfile, 'w') as f:
+    folder = Path(folder)
+    folder.mkdir(parents=True, exist_ok=True)
+    outfile = folder / 'manifest.json'
+    with outfile.open('w') as f:
         json.dump(manifest, f, indent=4)
 
 
@@ -237,34 +239,35 @@ def _create_invalid_manifest_azure(folder='.'):
     }
     """
     manifest = json.loads(manifest_str)
-    if not os.path.isdir(folder):
-        os.makedirs(folder)
-    outfile = os.path.join(folder, 'manifest.json')
-    with open(outfile, 'w') as f:
+    folder = Path(folder)
+    folder.mkdir(parents=True, exist_ok=True)
+    outfile = folder / 'manifest.json'
+    with outfile.open('w') as f:
         json.dump(manifest, f, indent=4)
 
 
 def _create_dummy_template_files(files=EXPECTED_OUTPUT_PROJ_FILES, folder='.'):
-    if not os.path.isdir(folder):
-        os.makedirs(folder)
+    folder = Path(folder)
+    folder.mkdir(parents=True, exist_ok=True)
 
-    os.makedirs(os.path.join(folder, 'testproject', 'agogosml'))
-    os.makedirs(os.path.join(folder, 'testproject', 'input_reader'))
-    os.makedirs(os.path.join(folder, 'testproject', 'output_writer'))
-    os.makedirs(os.path.join(folder, 'testproject', 'testproject'))
+    (folder / 'testproject' / 'agogosml').mkdir(parents=True, exist_ok=True)
+    (folder / 'testproject' / 'input_reader').mkdir(parents=True, exist_ok=True)
+    (folder / 'testproject' / 'output_writer').mkdir(parents=True, exist_ok=True)
+    (folder / 'testproject' / 'testproject').mkdir(parents=True, exist_ok=True)
 
     for proj_file in files:
-        outfile = os.path.join(folder, proj_file)
+        outfile = folder / proj_file
 
-        with open(outfile, 'w') as f:
+        with outfile.open('w') as f:
             json.dump("test content", f, indent=4)
 
 
 def _get_md5_template_files(files=EXPECTED_OUTPUT_PROJ_FILES, folder='.'):
     """Get the md5 hashes of the project files. Used to know if files were
     overwritten"""
+    folder = Path(folder)
     allmd5 = []
     for proj_file in files:
-        outfile = os.path.join(folder, proj_file)
+        outfile = folder / proj_file
         allmd5.append(test_utils.md5(outfile))
     return allmd5

--- a/agogosml_cli/tests/test_utils.py
+++ b/agogosml_cli/tests/test_utils.py
@@ -5,11 +5,14 @@
 
 
 import hashlib
+from pathlib import Path
+from typing import Union
 
 
-def md5(fname):
+def md5(path: Union[Path, str]):
+    path = Path(path)
     hash_md5 = hashlib.md5()
-    with open(fname, "rb") as f:
+    with path.open("rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()


### PR DESCRIPTION
This pull request refactors all references to `os.path` to use the new [pathlib module](https://docs.python.org/3/library/pathlib.html).

This makes the code a lot more natural to read. See [PEP 428](https://www.python.org/dev/peps/pep-0428/#why-an-object-oriented-api) for more information on why `pathlib` is a desirable improvement over the more low-level `os.path`.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability. **Not applicable: pure refactor**
- [x] Is this code designed to be testable? **Not applicable: pure refactor**
- [x] Is the code documented well? **Not applicable: pure refactor**
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)? **Docker build passes**
- [x] Have you added tests to cover your changes? **Not applicable: pure refactor**
- [x] Have you linted your code prior to submission? **Docker build passes**
- [x] Have you updated the documentation and README? **Not applicable: pure refactor**
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). **Not applicable: none included**
- [x] Have secrets been stripped before committing? **Not applicable: none included**
