### PR TITLE
Make client class lookup dynamic in factory

### DIFF
--- a/agogosml/agogosml/reader/input_reader_factory.py
+++ b/agogosml/agogosml/reader/input_reader_factory.py
@@ -31,14 +31,15 @@ class InputReaderFactory:
             raise Exception('No config were set for the InputReader manager')
 
         if streaming_client is None:
-            if config.get("client") is None:
+            try:
+                client_config = config['client']['config']
+                client_type = config['client']['type']
+            except KeyError:
                 raise Exception('client cannot be empty')
 
-            client_config = config.get('client')['config']
-            client_type = config.get('client')['type']
-
-            client_class = find_streaming_clients().get(client_type)
-            if client_class is None:
+            try:
+                client_class = find_streaming_clients()[client_type]
+            except KeyError:
                 raise Exception('Unknown client type')
 
             client = client_class(client_config)

--- a/agogosml/agogosml/reader/input_reader_factory.py
+++ b/agogosml/agogosml/reader/input_reader_factory.py
@@ -28,32 +28,26 @@ class InputReaderFactory:
         :return InputReader: An instance of an InputReader with streaming_client and message_sender
         """
         if InputReaderFactory.is_empty(config):
-            raise Exception('''
-            No config were set for the InputReader manager
-            ''')
+            raise Exception('No config were set for the InputReader manager')
 
         if streaming_client is None:
             if config.get("client") is None:
-                raise Exception('''
-                client cannot be empty
-                ''')
+                raise Exception('client cannot be empty')
 
-            client_config = config.get("client")["config"]
-            client_type = config.get("client")["type"]
+            client_config = config.get('client')['config']
+            client_type = config.get('client')['type']
 
             client_class = find_streaming_clients().get(client_type)
             if client_class is None:
-                raise Exception('''
-                Unknown client type
-                ''')
+                raise Exception('Unknown client type')
 
             client = client_class(client_config)
         else:
             client = streaming_client
 
         # host and port from the client
-        app_host = config.get("APP_HOST")
-        app_port = config.get("APP_PORT")
+        app_host = config.get('APP_HOST')
+        app_port = config.get('APP_PORT')
 
         msg_sender = HttpMessageSender(app_host, app_port)
 

--- a/agogosml/agogosml/tools/sender.py
+++ b/agogosml/agogosml/tools/sender.py
@@ -3,52 +3,13 @@
 from argparse import ArgumentParser
 from argparse import ArgumentTypeError
 from argparse import FileType
-from importlib import import_module
-from inspect import getsourcefile
-from pathlib import Path
-from pkgutil import walk_packages
 from sys import stdin
 from typing import IO
 from typing import Dict
-from typing import Iterable
 from typing import Tuple
-from typing import Type
-from typing import TypeVar
 
-from agogosml.common.abstract_streaming_client import AbstractStreamingClient
-
-T = TypeVar('T')
-SenderType = Type[AbstractStreamingClient]
-
-
-def get_base_module(interface) -> Tuple[str, Path]:
-    base_module_name = '.'.join(interface.__module__.split('.')[:-1])
-    base_module_path = Path(getsourcefile(interface)).parent
-    return base_module_name, base_module_path
-
-
-def import_subpackages(module_prefix: str, module_path: Path):
-    for _, module, _ in walk_packages([str(module_path)]):
-        sub_module_name = '{}.{}'.format(module_prefix, module)
-        import_module(sub_module_name)
-
-
-def find_implementations(interface: Type[T]) -> Iterable[Type[T]]:
-    base_module_name, base_module_path = get_base_module(interface)
-    import_subpackages(base_module_name, base_module_path)
-    return interface.__subclasses__()
-
-
-def find_senders() -> Dict[str, SenderType]:
-    """
-    >>> senders = find_senders()
-    >>> sorted(senders.keys())
-    ['eventhub', 'kafka', 'mock']
-    """
-    return {
-        client.__name__.replace('StreamingClient', '').lower(): client
-        for client in find_implementations(AbstractStreamingClient)
-    }
+from agogosml.reader.input_reader_factory import StreamingClientType
+from agogosml.reader.input_reader_factory import find_streaming_clients
 
 
 def key_value_arg(value: str) -> Tuple[str, str]:
@@ -67,27 +28,27 @@ def key_value_arg(value: str) -> Tuple[str, str]:
     return parts[0], parts[1]
 
 
-def main(messages: IO[str], sender_class: SenderType, config: Dict[str, str]):
+def main(messages: IO[str], sender_class: StreamingClientType, config: Dict[str, str]):
     sender = sender_class(config)
     for message in messages:
         sender.send(message.rstrip('\r\n'))
 
 
 def cli():
-    senders = find_senders()
+    streaming_clients = find_streaming_clients()
 
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--infile', type=FileType('r', encoding='utf-8'),
                         required=True, default=stdin,
                         help='File with events to send')
-    parser.add_argument('--sender', choices=sorted(senders),
+    parser.add_argument('--sender', choices=sorted(streaming_clients),
                         required=True, default='kafka',
                         help='The sender to use')
     parser.add_argument('config', nargs='*', type=key_value_arg,
                         help='Key-value configuration passed to the sender')
     args = parser.parse_args()
 
-    main(args.infile, senders[args.sender], dict(args.config))
+    main(args.infile, streaming_clients[args.sender], dict(args.config))
 
 
 if __name__ == '__main__':

--- a/agogosml/agogosml/utils/imports.py
+++ b/agogosml/agogosml/utils/imports.py
@@ -1,0 +1,28 @@
+from importlib import import_module
+from inspect import getsourcefile
+from pathlib import Path
+from pkgutil import walk_packages
+from typing import Iterable
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+T = TypeVar('T')
+
+
+def get_base_module(interface) -> Tuple[str, Path]:
+    base_module_name = '.'.join(interface.__module__.split('.')[:-1])
+    base_module_path = Path(getsourcefile(interface)).parent
+    return base_module_name, base_module_path
+
+
+def import_subpackages(module_prefix: str, module_path: Path):
+    for _, module, _ in walk_packages([str(module_path)]):
+        sub_module_name = '{}.{}'.format(module_prefix, module)
+        import_module(sub_module_name)
+
+
+def find_implementations(interface: Type[T]) -> Iterable[Type[T]]:
+    base_module_name, base_module_path = get_base_module(interface)
+    import_subpackages(base_module_name, base_module_path)
+    return interface.__subclasses__()


### PR DESCRIPTION
Currently, the InputReaderFactory has a hard-coded list of streaming clients which it can instantiate. This change ports the dynamic instantiation from the sender tool to the factory to remove the hard-coding and enable the factory to create arbitrary clients.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README? **Not applicable: refactor**
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). **Not applicable: refactor**
- [x] Have secrets been stripped before committing? **Not applicable: refactor**
