### PR TITLE
Accept arbitrary streaming client configuration

### DIFF
--- a/agogosml/agogosml/common/abstract_streaming_client.py
+++ b/agogosml/agogosml/common/abstract_streaming_client.py
@@ -11,7 +11,7 @@ from agogosml.utils.imports import find_implementations
 
 class AbstractStreamingClient(ABC):
     @abstractmethod
-    def __init__(self, config: Dict[str, str]):
+    def __init__(self, config: dict):
         """
         Abstract Streaming Client
 

--- a/agogosml/agogosml/tools/sender.py
+++ b/agogosml/agogosml/tools/sender.py
@@ -3,29 +3,29 @@
 from argparse import ArgumentParser
 from argparse import ArgumentTypeError
 from argparse import FileType
+from json import loads
 from sys import stdin
 from typing import IO
 from typing import Dict
-from typing import Tuple
 
 from agogosml.common.abstract_streaming_client import StreamingClientType
 from agogosml.common.abstract_streaming_client import find_streaming_clients
 
 
-def key_value_arg(value: str) -> Tuple[str, str]:
+def json_arg(value: str):
     """
-    >>> key_value_arg('foo=bar')
-    ('foo', 'bar')
+    >>> json_arg('{"foo": "bar", "baz": [1, 2]}')
+    {'foo': 'bar', 'baz': [1, 2]}
 
-    >>> key_value_arg('badValue')
+    >>> json_arg('{')
     Traceback (most recent call last):
         ...
-    argparse.ArgumentTypeError: badValue is not in format key=value
+    argparse.ArgumentTypeError: { is not in JSON format
     """
-    parts = value.split('=')
-    if len(parts) != 2:
-        raise ArgumentTypeError('{} is not in format key=value'.format(value))
-    return parts[0], parts[1]
+    try:
+        return loads(value)
+    except ValueError:
+        raise ArgumentTypeError('{} is not in JSON format'.format(value))
 
 
 def main(messages: IO[str], sender_class: StreamingClientType, config: Dict[str, str]):
@@ -44,11 +44,11 @@ def cli():
     parser.add_argument('--sender', choices=sorted(streaming_clients),
                         required=True, default='kafka',
                         help='The sender to use')
-    parser.add_argument('config', nargs='*', type=key_value_arg,
-                        help='Key-value configuration passed to the sender')
+    parser.add_argument('config', type=json_arg,
+                        help='JSON configuration passed to the sender')
     args = parser.parse_args()
 
-    main(args.infile, streaming_clients[args.sender], dict(args.config))
+    main(args.infile, streaming_clients[args.sender], args.config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, the type definition for the streaming client interface specified a string-string dictionary. However, arbitrary json inputs are supported. This change fixes the type definition and related tooling.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [x] Have secrets been stripped before committing? 
