### PR TITLE
Add broadcast streaming client

### DIFF
--- a/agogosml/agogosml/common/abstract_streaming_client.py
+++ b/agogosml/agogosml/common/abstract_streaming_client.py
@@ -43,7 +43,7 @@ def find_streaming_clients() -> Dict[str, StreamingClientType]:
     """
     >>> senders = find_streaming_clients()
     >>> sorted(senders.keys())
-    ['eventhub', 'kafka', 'mock']
+    ['broadcast', 'eventhub', 'kafka', 'mock']
     """
     return {
         client.__name__.replace('StreamingClient', '').lower(): client

--- a/agogosml/agogosml/common/broadcast_streaming_client.py
+++ b/agogosml/agogosml/common/broadcast_streaming_client.py
@@ -1,0 +1,43 @@
+from .abstract_streaming_client import AbstractStreamingClient
+from .abstract_streaming_client import create_streaming_client_from_config
+
+
+class BroadcastStreamingClient(AbstractStreamingClient):
+    def __init__(self, config: dict):
+        """
+        Class to create a BroadcastStreamingClient instance.
+
+        Configuration keys:
+          CLIENTS
+
+        :param config: Dictionary file with all the relevant parameters.
+        """
+
+        self.clients = [
+            create_streaming_client_from_config(conf)
+            if not isinstance(conf, AbstractStreamingClient) else conf
+            for conf in config.get('CLIENTS', [])
+        ]
+
+    def start_receiving(self, on_message_received_callback):
+        """
+        Receive messages from all the clients
+
+        :param on_message_received_callback: Callback function.
+        """
+        raise NotImplementedError
+
+    def send(self, message):
+        """
+        Send a message to all the clients
+
+        :param message: A string input to upload to event hub.
+        """
+        success = True
+        for client in self.clients:
+            success &= client.send(message)
+        return success
+
+    def stop(self):
+        for client in self.clients:
+            client.stop()

--- a/agogosml/tests/client_mocks.py
+++ b/agogosml/tests/client_mocks.py
@@ -7,7 +7,7 @@ class StreamingClientMock(AbstractStreamingClient):
     """
     A class to mock functionality at the streaming client level.
     """
-    def __init__(self):
+    def __init__(self, config: dict = None):
         self.sent = False
         self.receiving = False
         self.last_message = None

--- a/agogosml/tests/client_mocks.py
+++ b/agogosml/tests/client_mocks.py
@@ -15,7 +15,7 @@ class StreamingClientMock(AbstractStreamingClient):
         pass
 
     def send(self, msg):
-        print('Streaming Client Mock send message: '+msg)
+        print('Streaming Client Mock send message:', msg)
         if self.should_fail_to_send:
             self.sent = False
             return False


### PR DESCRIPTION
Should be reviewed after https://github.com/Microsoft/agogosml/pull/222 since this pull request depends on that branch.

This pull request adds a wrapper streaming client which enables distribution of a message to multiple streaming client implementations. This is useful to for example configure an output writer which sends outputs to both kafka and eventhub.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [x] Have secrets been stripped before committing? 
