### PR TITLE
Abstract listener client and message sender interfaces

### DIFF
--- a/agogosml/agogosml/common/flask_http_listener_client.py
+++ b/agogosml/agogosml/common/flask_http_listener_client.py
@@ -10,9 +10,15 @@ DEFAULT_HOST = '127.0.0.1'
 
 
 class FlaskHttpListenerClient(ListenerClient):
-    def __init__(self, port, host=DEFAULT_HOST):
-        self.port = port
-        self.host = host
+    def __init__(self, config: dict):
+        """
+        Configuration keys:
+
+            PORT
+            HOST
+        """
+        self.port = int(config.get('PORT'))
+        self.host = config.get('HOST', DEFAULT_HOST)
 
     def thread_flask(self):
         app = Flask(__name__)

--- a/agogosml/agogosml/common/http_message_sender.py
+++ b/agogosml/agogosml/common/http_message_sender.py
@@ -11,12 +11,16 @@ logger = Logger()
 class HttpMessageSender(MessageSender):
     """HttpMessageSender."""
 
-    def __init__(self, host_endpoint, port_endpoint):
+    def __init__(self, config: dict):
         """
+        Configuration keys:
 
-        :param host_endpoint: Host endpoint.
-        :param port_endpoint: Port number.
+            HOST
+            PORT
         """
+        host_endpoint = config.get('HOST')
+        port_endpoint = config.get('PORT')
+
         logger.info("host_endpoint: {}".format(host_endpoint))
         logger.info("port_endpoint: {}".format(port_endpoint))
 

--- a/agogosml/agogosml/common/listener_client.py
+++ b/agogosml/agogosml/common/listener_client.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 class ListenerClient(ABC):
 
     @abstractmethod
-    def __init__(self, port, host):
+    def __init__(self, config: dict):
         pass
 
     @abstractmethod

--- a/agogosml/agogosml/common/message_sender.py
+++ b/agogosml/agogosml/common/message_sender.py
@@ -8,7 +8,7 @@ class MessageSender(ABC):
     """Message Sender class."""
 
     @abstractmethod
-    def __init__(self):
+    def __init__(self, config: dict):
         pass
 
     @abstractmethod

--- a/agogosml/agogosml/reader/input_reader_factory.py
+++ b/agogosml/agogosml/reader/input_reader_factory.py
@@ -50,7 +50,7 @@ class InputReaderFactory:
         app_host = config.get('APP_HOST')
         app_port = config.get('APP_PORT')
 
-        msg_sender = HttpMessageSender(app_host, app_port)
+        msg_sender = HttpMessageSender({'HOST': app_host, 'PORT': app_port})
 
         return InputReader(client, msg_sender)
 

--- a/agogosml/agogosml/writer/output_writer_factory.py
+++ b/agogosml/agogosml/writer/output_writer_factory.py
@@ -54,7 +54,7 @@ class OutputWriterFactory:
             port = config.get("OUTPUT_WRITER_PORT")
             host = config.get("OUTPUT_WRITER_HOST")
 
-            listener = FlaskHttpListenerClient(port, host)
+            listener = FlaskHttpListenerClient({'PORT': port, 'HOST': host})
         else:
             listener = listener_client
 

--- a/agogosml/tests/client_mocks.py
+++ b/agogosml/tests/client_mocks.py
@@ -52,7 +52,7 @@ class HttpClientMock(ListenerClient):
     """
     A class to mock functionality at the http client level
     """
-    def __init__(self, port):
+    def __init__(self, config: dict):
         self.callback = None
         self.startCalled = False
         self.stopCalled = False

--- a/agogosml/tests/client_mocks.py
+++ b/agogosml/tests/client_mocks.py
@@ -77,7 +77,7 @@ class HttpClientMock(ListenerClient):
 
 
 class MessageSenderMock(MessageSender):
-    def __init__(self):
+    def __init__(self, config: dict):
         self.msg = None
         self.should_fail_to_send = None
         pass

--- a/agogosml/tests/client_mocks.py
+++ b/agogosml/tests/client_mocks.py
@@ -7,7 +7,7 @@ class StreamingClientMock(AbstractStreamingClient):
     """
     A class to mock functionality at the streaming client level.
     """
-    def __init__(self):
+    def __init__(self, config: dict = None):
         self.sent = False
         self.receiving = False
         self.last_message = None
@@ -52,7 +52,7 @@ class HttpClientMock(ListenerClient):
     """
     A class to mock functionality at the http client level
     """
-    def __init__(self, config: dict):
+    def __init__(self, config: dict = None):
         self.callback = None
         self.startCalled = False
         self.stopCalled = False
@@ -77,7 +77,7 @@ class HttpClientMock(ListenerClient):
 
 
 class MessageSenderMock(MessageSender):
-    def __init__(self, config: dict):
+    def __init__(self, config: dict = None):
         self.msg = None
         self.should_fail_to_send = None
         pass

--- a/agogosml/tests/integration_tests/test_app.py
+++ b/agogosml/tests/integration_tests/test_app.py
@@ -9,7 +9,7 @@ class TestApp:
 
     def __init__(self, app_port, app_host, output_port, output_host):
         self.listener = FlaskHttpListenerClient({'PORT': app_port, 'HOST': app_host})
-        self.sender = HttpMessageSender(output_host, output_port)
+        self.sender = HttpMessageSender({'HOST': output_host, 'PORT': output_port})
 
     def start(self):
         self.listener.start(self.on_message_received)

--- a/agogosml/tests/integration_tests/test_app.py
+++ b/agogosml/tests/integration_tests/test_app.py
@@ -8,7 +8,7 @@ logger = Logger()
 class TestApp:
 
     def __init__(self, app_port, app_host, output_port, output_host):
-        self.listener = FlaskHttpListenerClient(app_port, app_host)
+        self.listener = FlaskHttpListenerClient({'PORT': app_port, 'HOST': app_host})
         self.sender = HttpMessageSender(output_host, output_port)
 
     def start(self):

--- a/agogosml/tests/integration_tests/test_integration_input_app_output.py
+++ b/agogosml/tests/integration_tests/test_integration_input_app_output.py
@@ -22,7 +22,7 @@ def mock_streaming_client():
 
 @pytest.fixture
 def mock_listener_client():
-    return HttpClientMock(0)
+    return HttpClientMock({'PORT': 0})
 
 
 @pytest.mark.integration

--- a/agogosml/tests/test_output_writer.py
+++ b/agogosml/tests/test_output_writer.py
@@ -15,7 +15,7 @@ def mock_streaming_client():
 
 @pytest.fixture
 def mock_listener_client():
-    return HttpClientMock(0)
+    return HttpClientMock({'PORT': 0})
 
 
 def test_when_ctor_instance_created(mock_streaming_client, mock_listener_client):


### PR DESCRIPTION
Unlike the streaming client, the listener client and message sender interfaces are concrete in the types of arguments that all of its implementations receive (e.g. port and host). However, there are potential implementations for which these arguments won't be appropriate (e.g. a docker-client based message sender). As such, this pull request refactors the constructor signatures to follow the config-dictionary pattern. This will also enable dynamic creation and configuration of the classes in the future.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [x] Have secrets been stripped before committing? 
