### PR TITLE
allow running via docker

### DIFF
--- a/agogosml_cli/Dockerfile
+++ b/agogosml_cli/Dockerfile
@@ -36,4 +36,6 @@ RUN pip install /dist/agogosml_cli-*.tar.gz
 
 RUN apk del .build-deps
 
+WORKDIR /home
+
 ENTRYPOINT ["agogosml"]


### PR DESCRIPTION
This permis the Docker container to be run using a command such as 
```
docker run -it --rm -v "$(pwd):/home" agogosml-cli init
```
The output of the above command is the `manifest.json` in the `$(pwd)` provided.

> Prior to this change, the container would be started in the root `/` and that is not permitted to be mapped to the host.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [x] Have secrets been stripped before committing? 
