### PR TITLE
changes to fix issue 246

### DIFF
--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/Dockerfile.input_reader
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/Dockerfile.input_reader
@@ -1,7 +1,7 @@
 ARG CONTAINER_REG
 ARG AGOGOSML_TAG="latest"
 
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} as builder
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} as builder
 
 WORKDIR /usr/src/agogosml
 COPY . ./input_reader
@@ -10,7 +10,7 @@ COPY . ./input_reader
 RUN apk add ca-certificates
 
 # Release
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} AS input_reader
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} AS input_reader
 
 WORKDIR /input_reader
 COPY --from=builder /usr/src/agogosml/input_reader /input_reader

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/Dockerfile.output_writer
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/Dockerfile.output_writer
@@ -1,7 +1,7 @@
 ARG CONTAINER_REG
 ARG AGOGOSML_TAG="latest"
 
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} as builder
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} as builder
 
 # Copy the app
 WORKDIR /usr/src/agogosml
@@ -11,7 +11,7 @@ COPY . ./output_writer
 RUN apk add ca-certificates
 
 # Release
-FROM ${CONTAINER_REG}agogosml:${AGOGOSML_TAG} AS output_writer
+FROM ${CONTAINER_REG}/agogosml:${AGOGOSML_TAG} AS output_writer
 
 WORKDIR /output_writer
 COPY --from=builder /usr/src/agogosml/output_writer /output_writer


### PR DESCRIPTION
### All Submissions:

- [ X] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [ X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [ X] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [X ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [ ] Is this code designed to be testable? 
- [ ] Is the code documented well?
- [ ] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [ ] Have you added tests to cover your changes?
- [ ] Have you linted your code prior to submission?
- [ ] Have you updated the documentation and README?
- [ ] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [ ] Have secrets been stripped before committing? 

This PR fixes #246 . The missing forward slash in the input reader and output writer docker files causes the Azure devops builds to fail. 

Changes done
* I have modified the docker file templates of input reader and output writer to include the correct path which fixes issue.

Azure Devops build is successful after adding these changes
