### PR TITLE
Remove config duplication

### DIFF
--- a/agogosml/agogosml/common/broadcast_streaming_client.py
+++ b/agogosml/agogosml/common/broadcast_streaming_client.py
@@ -11,13 +11,13 @@ class BroadcastStreamingClient(AbstractStreamingClient):
         Streaming client implementation that broadcases across multiple clients.
 
         Configuration keys:
-          CLIENTS
+          BROADCAST_CLIENTS
         """
 
         self.clients = [
             create_streaming_client_from_config(conf)
             if not isinstance(conf, AbstractStreamingClient) else conf
-            for conf in config.get('CLIENTS', [])
+            for conf in config.get('BROADCAST_CLIENTS', [])
         ]
 
     def start_receiving(self, on_message_received_callback):

--- a/agogosml/agogosml/utils/config.py
+++ b/agogosml/agogosml/utils/config.py
@@ -1,0 +1,54 @@
+"""Configuration utilities"""
+from ast import literal_eval
+from json import JSONDecodeError
+from json import loads
+
+
+class Config:
+    """Dictionary wrapper that converts string values to Python objects"""
+    def __init__(self, config):
+        self.__config = config
+
+    def __getitem__(self, item):
+        """Get a key"""
+        value = self.__config[item]
+        return to_python(value)
+
+    def get(self, item, default=None):
+        """Get a key or the default value if the key doesn't exist"""
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
+
+def to_python(value):
+    """Convert a string value to a python object.
+
+    >>> json_value = '{"foo": "bar"}'
+    >>> to_python(json_value)
+    {'foo': 'bar'}
+    >>> ast_value = "[1, '2', 3]"
+    >>> to_python(ast_value)
+    [1, '2', 3]
+    >>> string_value = 'value'
+    >>> to_python(string_value)
+    'value'
+    >>> already_parsed_value = ['a', 1]
+    >>> to_python(already_parsed_value)
+    ['a', 1]
+    """
+    if not isinstance(value, str):
+        return value
+
+    try:
+        return loads(value)
+    except JSONDecodeError:
+        pass
+
+    try:
+        return literal_eval(value)
+    except (SyntaxError, ValueError):
+        pass
+
+    return value

--- a/agogosml/tests/test_output_writer.py
+++ b/agogosml/tests/test_output_writer.py
@@ -37,7 +37,7 @@ def test_on_message_received_sent_called(mock_streaming_client,
 def test_broadcast_success(*fixtures):
     mock1 = StreamingClientMock()
     mock2 = StreamingClientMock()
-    broadcast = BroadcastStreamingClient({'CLIENTS': [mock1, mock2]})
+    broadcast = BroadcastStreamingClient({'BROADCAST_CLIENTS': [mock1, mock2]})
 
     success = broadcast.send({'test': 'message'})
 
@@ -49,7 +49,7 @@ def test_broadcast_failure(*fixtures):
     mock1 = StreamingClientMock()
     mock2 = StreamingClientMock()
     mock3 = StreamingClientMock()
-    broadcast = BroadcastStreamingClient({'CLIENTS': [mock1, mock2, mock3]})
+    broadcast = BroadcastStreamingClient({'BROADCAST_CLIENTS': [mock1, mock2, mock3]})
 
     mock2.set_fail_send(True)
     success = broadcast.send({'test': 'message'})
@@ -59,7 +59,7 @@ def test_broadcast_failure(*fixtures):
 
 
 def test_broadcast_create_from_config(*fixtures):
-    broadcast = BroadcastStreamingClient({'CLIENTS': [
+    broadcast = BroadcastStreamingClient({'BROADCAST_CLIENTS': [
         {'type': 'mock', 'config': {}},
         {'type': 'mock', 'config': {}},
     ]})

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/main.py
@@ -7,11 +7,14 @@ from agogosml.reader.input_reader_factory import InputReaderFactory
 from agogosml.utils.config import Config
 
 if __name__ == "__main__":
+    config = dict(os.environ)
+    if 'KAFKA_TOPIC_INPUT' in config:
+        config['KAFKA_TOPIC'] = config.pop('KAFKA_TOPIC_INPUT')
 
     CFG = {
         'client': {
             'type': os.getenv("MESSAGING_TYPE"),
-            'config': Config(os.environ),
+            'config': Config(config),
         },
         'APP_HOST': os.getenv('APP_HOST'),
         'APP_PORT': os.getenv('APP_PORT'),

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/main.py
@@ -7,44 +7,14 @@ from agogosml.reader.input_reader_factory import InputReaderFactory
 
 if __name__ == "__main__":
 
-    msg_type = os.getenv("MESSAGING_TYPE")
-    CFG = None
-
-    if msg_type == 'eventhub':
-        CFG = {
-            'client': {
-                'type': 'eventhub',
-                'config': {
-                    'AZURE_STORAGE_ACCOUNT': os.getenv("AZURE_STORAGE_ACCOUNT"),
-                    'AZURE_STORAGE_ACCESS_KEY': os.getenv("AZURE_STORAGE_ACCESS_KEY"),
-                    'EVENT_HUB_NAMESPACE': os.getenv("EVENT_HUB_NAMESPACE"),
-                    'EVENT_HUB_NAME': os.getenv("EVENT_HUB_NAME"),
-                    'EVENT_HUB_SAS_POLICY': os.getenv("EVENT_HUB_SAS_POLICY"),
-                    'EVENT_HUB_SAS_KEY': os.getenv("EVENT_HUB_SAS_KEY"),
-                    'LEASE_CONTAINER_NAME': os.getenv("LEASE_CONTAINER_NAME"),
-                    'TIMEOUT': os.getenv('TIMEOUT')
-                }
-            },
-            'APP_HOST': os.getenv('APP_HOST'),
-            'APP_PORT': os.getenv('APP_PORT'),
-        }
-    elif msg_type == 'kafka':
-        CFG = {
-            'client': {
-                'type': 'kafka',
-                'config': {
-                    'KAFKA_TOPIC': os.getenv("KAFKA_TOPIC_INPUT"),
-                    'KAFKA_CONSUMER_GROUP': os.getenv("KAFKA_CONSUMER_GROUP"),
-                    'KAFKA_ADDRESS': os.getenv("KAFKA_ADDRESS"),
-                    'TIMEOUT': os.getenv('TIMEOUT'),
-                    # Specific to Event Hub Head for Kafka
-                    'EVENTHUB_KAFKA_CONNECTION_STRING': os.getenv('EVENTHUB_KAFKA_CONNECTION_STRING'),
-                    'SSL_CERT_LOCATION': os.getenv('SSL_CERT_LOCATION')
-                }
-            },
-            'APP_HOST': os.getenv("APP_HOST"),
-            'APP_PORT': os.getenv("APP_PORT"),
-        }
+    CFG = {
+        'client': {
+            'type': os.getenv("MESSAGING_TYPE"),
+            'config': os.environ,
+        },
+        'APP_HOST': os.getenv('APP_HOST'),
+        'APP_PORT': os.getenv('APP_PORT'),
+    }
 
     INPUT = InputReaderFactory.create(CFG)
     INPUT.start_receiving_messages()  # initiate receiving

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/input_reader/main.py
@@ -4,13 +4,14 @@ Main entry point for input reader
 import os
 
 from agogosml.reader.input_reader_factory import InputReaderFactory
+from agogosml.utils.config import Config
 
 if __name__ == "__main__":
 
     CFG = {
         'client': {
             'type': os.getenv("MESSAGING_TYPE"),
-            'config': os.environ,
+            'config': Config(os.environ),
         },
         'APP_HOST': os.getenv('APP_HOST'),
         'APP_PORT': os.getenv('APP_PORT'),

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
@@ -5,40 +5,16 @@ import os
 
 from agogosml.writer.output_writer_factory import OutputWriterFactory
 
-if __name__ == "__main__":
+if __name__ == '__main__':
 
-    msg_type = os.getenv("MESSAGING_TYPE")
-    CFG = None
+    CFG = {
+        'client': {
+            'type': os.getenv('MESSAGING_TYPE'),
+            'config': os.environ,
+        },
+        'OUTPUT_WRITER_PORT': os.getenv('OUTPUT_WRITER_PORT'),
+        'OUTPUT_WRITER_HOST': os.getenv('OUTPUT_WRITER_HOST'),
+    }
 
-    if msg_type == 'eventhub':
-        CFG = {
-            'client': {
-                'type': 'eventhub',
-                'config': {
-                    'EVENT_HUB_NAMESPACE': os.getenv("EVENT_HUB_NAMESPACE"),
-                    'EVENT_HUB_NAME': os.getenv("EVENT_HUB_NAME"),
-                    'EVENT_HUB_SAS_POLICY': os.getenv("EVENT_HUB_SAS_POLICY"),
-                    'EVENT_HUB_SAS_KEY': os.getenv("EVENT_HUB_SAS_KEY"),
-                }
-            },
-            'OUTPUT_WRITER_PORT': os.getenv("OUTPUT_WRITER_PORT"),
-            'OUTPUT_WRITER_HOST': os.getenv("OUTPUT_WRITER_HOST"),
-        }
-    elif msg_type == 'kafka':
-        CFG = {
-            'client': {
-                'type': 'kafka',
-                'config': {
-                    'KAFKA_TOPIC': os.getenv("KAFKA_TOPIC_INPUT"),
-                    'KAFKA_ADDRESS': os.getenv("KAFKA_ADDRESS"),
-                    'TIMEOUT': os.getenv('TIMEOUT'),
-                    # Specific to Event Hub Head for Kafka
-                    'EVENTHUB_KAFKA_CONNECTION_STRING': os.getenv('EVENTHUB_KAFKA_CONNECTION_STRING'),
-                    'SSL_CERT_LOCATION': os.getenv('SSL_CERT_LOCATION')
-                }
-            },
-            'OUTPUT_WRITER_PORT': os.getenv("OUTPUT_WRITER_PORT"),
-            'OUTPUT_WRITER_HOST': os.getenv("OUTPUT_WRITER_HOST"),
-        }
     OUTPUT = OutputWriterFactory.create(CFG)
     OUTPUT.start_incoming_messages()

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
@@ -3,6 +3,7 @@ Main entry point for output writer
 """
 import os
 
+from agogosml.utils.config import Config
 from agogosml.writer.output_writer_factory import OutputWriterFactory
 
 if __name__ == '__main__':
@@ -10,7 +11,7 @@ if __name__ == '__main__':
     CFG = {
         'client': {
             'type': os.getenv('MESSAGING_TYPE'),
-            'config': os.environ,
+            'config': Config(os.environ),
         },
         'OUTPUT_WRITER_PORT': os.getenv('OUTPUT_WRITER_PORT'),
         'OUTPUT_WRITER_HOST': os.getenv('OUTPUT_WRITER_HOST'),

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
@@ -7,11 +7,14 @@ from agogosml.utils.config import Config
 from agogosml.writer.output_writer_factory import OutputWriterFactory
 
 if __name__ == '__main__':
+    config = dict(os.environ)
+    if 'KAFKA_TOPIC_INPUT' in config:
+        config['KAFKA_TOPIC'] = config.pop('KAFKA_TOPIC_INPUT')
 
     CFG = {
         'client': {
             'type': os.getenv('MESSAGING_TYPE'),
-            'config': Config(os.environ),
+            'config': Config(config),
         },
         'OUTPUT_WRITER_PORT': os.getenv('OUTPUT_WRITER_PORT'),
         'OUTPUT_WRITER_HOST': os.getenv('OUTPUT_WRITER_HOST'),

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/output_writer/main.py
@@ -8,8 +8,8 @@ from agogosml.writer.output_writer_factory import OutputWriterFactory
 
 if __name__ == '__main__':
     config = dict(os.environ)
-    if 'KAFKA_TOPIC_INPUT' in config:
-        config['KAFKA_TOPIC'] = config.pop('KAFKA_TOPIC_INPUT')
+    if 'KAFKA_TOPIC_OUTPUT' in config:
+        config['KAFKA_TOPIC'] = config.pop('KAFKA_TOPIC_OUTPUT')
 
     CFG = {
         'client': {


### PR DESCRIPTION
This change includes:
- Make broadcast clients config key more explicit
- Remove redundant configuration specification
- Enable non-string values to be passed as config

Also @margaretmeehan take a look at 07ae916; I wonder if this odd naming was the cause of the earlier bug you saw where the pipeline only works with specific topics. It's a bit odd to me that the output writer would look at the KAFKA_TOPIC_INPUT environment variable instead of the OUTPUT one so I replaced that env deference.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [x] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [x] Is this code designed to be testable? 
- [x] Is the code documented well?
- [x] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [x] Have you added tests to cover your changes?
- [x] Have you linted your code prior to submission?
- [x] Have you updated the documentation and README?
- [x] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [x] Have secrets been stripped before committing? 
