### PR TITLE
Added helm init to CD template

### DIFF
--- a/agogosml_cli/cli/templates/pipeline/azure-cd-pipeline.jsonnet
+++ b/agogosml_cli/cli/templates/pipeline/azure-cd-pipeline.jsonnet
@@ -201,6 +201,24 @@
                         },
                         {
                             "environment": {},
+                            "taskId": "79d92bb0-5cae-11e7-94c2-fff61a32ec2a",
+                            "version": "1.*",
+                            "name": "helm ",
+                            "refName": "",
+                            "enabled": true,
+                            "alwaysRun": false,
+                            "continueOnError": true,
+                            "timeoutInMinutes": 0,
+                            "definitionType": "task",
+                            "overrideInputs": {},
+                            "condition": "succeeded()",
+                            "inputs": {
+                                "subCommand": "init",
+                                "arguments": ""
+                            }
+                        },
+                        {
+                            "environment": {},
                             "taskId": "cbc316a2-586f-4def-be79-488a1f503564",
                             "version": "0.*",
                             "name": "kubectl get",


### PR DESCRIPTION
Call helm init after helm install. Fails (or partially succeeds) and conintues if tiller is already installed in the clu

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Microsoft/agogosml/blob/master/CONTRIBUTING.rst) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Microsoft/agogosml/pulls) for the same update/change?
- [ ] Does your PR follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Does each method or function "do one thing well"? Reviewers may recommend methods be split up for maintainability and testability.
- [ ] Is this code designed to be testable? 
- [ ] Is the code documented well?
- [ ] Does your submission pass existing tests (or update existing tests with documentation regarding the change)?
- [ ] Have you added tests to cover your changes?
- [ ] Have you linted your code prior to submission?
- [ ] Have you updated the documentation and README?
- [ ] Is PII treated correctly? In particular, make sure the code is not logging objects or strings that might contain PII (e.g. request headers). 
- [ ] Have secrets been stripped before committing? 
