### PR TITLE
add svc endpoint bash check

### DIFF
--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/agogosml-ci-pipeline.yml
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/agogosml-ci-pipeline.yml
@@ -21,6 +21,16 @@ jobs:
   condition: succeeded()
 
   steps:
+  - bash: |
+      if [ -z "$(azure_subscription)" ]; then
+        echo "azure_subscription not set in variables - exiting"
+        exit 1
+      else
+        echo "using azure_subscription - $(azure_subscription)"
+      fi
+
+    displayName: 'verify YAML variable set for azure_subscription'
+
   - task: Docker@1
     displayName: 'Build an image'
     inputs:

--- a/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/app-ci-pipeline.yml
+++ b/agogosml_cli/cli/templates/{{cookiecutter.PROJECT_NAME_SLUG}}/app-ci-pipeline.yml
@@ -17,6 +17,16 @@ jobs:
 - job: Phase_1
     
   steps:
+  - bash: |
+      if [ -z "$(azure_subscription)" ]; then
+        echo "azure_subscription not set in variables - exiting"
+        exit 1
+      else
+        echo "using azure_subscription - $(azure_subscription)"
+      fi
+
+    displayName: 'verify YAML variable set for azure_subscription'
+    
   - task: Docker@1
     displayName: 'Build app image'
     inputs:


### PR DESCRIPTION
This adds a bash script check indicating if the variable for the Azure Service Endpoint is valid for the current build.  It uses the UUID of the Service Endpoint's ID as known by Azure DevOps.

This was run via init/generate - here: 

[agogosml-ci](https://dev.azure.com/scicoria-ms/ago2/_build/results?buildId=88)
[sample app - foobar ](https://dev.azure.com/scicoria-ms/ago2/_build/results?buildId=89)


