### PR TITLE
Fix isort skip of templates directory

### DIFF
--- a/agogosml_cli/Makefile
+++ b/agogosml_cli/Makefile
@@ -54,7 +54,7 @@ lint: ## check python style
 	flake8 cli tests
 	pylint cli
 	bandit -c .banditrc -r cli
-	isort --skip-glob '**/cli/templates/**' --check-only --recursive cli
+	isort --check-only --recursive cli
 
 test:
 	## Fail fast in CI, maxfail=1

--- a/agogosml_cli/setup.cfg
+++ b/agogosml_cli/setup.cfg
@@ -34,6 +34,8 @@ test = pytest
 [isort]
 force_single_line = True
 line_length = 120
+skip_glob = templates
+known_first_party = cli
 
 [tool:pytest]
 norecursedirs = 


### PR DESCRIPTION
Looking at the isort source ([here](https://github.com/timothycrosley/isort/blob/9bdd130d76bffeef06239fd9de90dfdab85d593e/isort/main.py#L94-L116) and [here](https://github.com/timothycrosley/isort/blob/91ae94e477d066f133a889d13f3bd25363785258/isort/settings.py#L374-L410)) it looks like previously we weren't using the isort skip option correctly.