### PR TITLE
Add option to send messages to multiple apps

### DIFF
--- a/agogosml/agogosml/common/http_message_sender.py
+++ b/agogosml/agogosml/common/http_message_sender.py
@@ -19,12 +19,14 @@ class HttpMessageSender(MessageSender):
             SCHEME
             RETRIES
             BACKOFF
+            EXTRA_URLS
         """
         host = config.get('HOST')
         port = config.get('PORT')
         scheme = config.get('SCHEME', 'http')
         retries = config.get('RETRIES', 3)
         backoff = config.get('BACKOFF', 1)
+        extra_urls = config.get('EXTRA_URLS') or []
 
         if not host:
             raise ValueError('Host endpoint must be provided.')
@@ -38,28 +40,37 @@ class HttpMessageSender(MessageSender):
         self.server_address = "%s://%s:%s" % (scheme, host, port)
         self.retries = retries
         self.backoff = backoff
+        self.extra_urls = extra_urls
 
         self.logger = Logger()
 
         self.logger.info("server_address: %s", self.server_address)
 
     def send(self, message):  # pragma: no cover
+        return_value = self._send(message, self.server_address)
+
+        for extra_url in self.extra_urls:
+            self._send(message, extra_url)
+
+        return return_value
+
+    def _send(self, message, url):
         return_value = False
         try:
             status_code = post_with_retries(
-                self.server_address, message,
+                url, message,
                 retries=self.retries,
                 backoff=self.backoff)
 
             if status_code != 200:
-                self.logger.error("Error with a request %s and message not sent was %s",
-                                  status_code, message)
-                print("Error with a request %s and message not sent was %s" %
-                      (status_code, message))
+                self.logger.error("[Server %s] Error with a request %s and message not sent was %s",
+                                  url, status_code, message)
+                print("[Server %s] Error with a request %s and message not sent was %s" %
+                      (url, status_code, message))
             else:
                 return_value = True
 
         except Exception as ex:
-            self.logger.error('Failed to send request: %s', ex)
+            self.logger.error('[Server %s] Failed to send request: %s', url, ex)
 
         return return_value

--- a/agogosml/agogosml/reader/input_reader_factory.py
+++ b/agogosml/agogosml/reader/input_reader_factory.py
@@ -21,7 +21,9 @@ class InputReaderFactory:
         # host and port from the client
         app_host = config.get('APP_HOST')
         app_port = config.get('APP_PORT')
+        app_extra_urls = config.get('APP_EXTRA_URLS')
 
-        msg_sender = HttpMessageSender({'HOST': app_host, 'PORT': app_port})
+        msg_sender = HttpMessageSender({'HOST': app_host, 'PORT': app_port,
+                                        'EXTRA_URLS': app_extra_urls})
 
         return InputReader(client, msg_sender)


### PR DESCRIPTION
This change adds an optional `APP_EXTRA_URLS` configuration section that enables a user to configure more than one app to which to send the input messages. This enables use-cases such as:

1) Deploying a "shadow model" which runs side-by-side with the main model for ongoing evaluation before making the model canonical.

2) Enabling ensembling of models by sending the same data-point to multiple models and merging the resulting predictions in another system.

Note that in order to maintain full backwards compatibility, the input reader currently does not error out if any of the requests to the extra apps failed.
